### PR TITLE
Add description from package to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 # rcldf is a library for R to read Cross-Linguistic Data files (CLDF)
 
+Cross-Linguistic Data Format (CLDF) is a framework for storing 
+cross-linguistic data, ensuring compatibility and ease of data exchange between
+different linguistic datasets see [Forkel et al. (2018)](https://doi.org/10.1038/sdata.2018.205). 
+The 'rcldf' package is designed to facilitate the manipulation and analysis of 
+these datasets by simplifying the loading, querying, and visualisation of CLDF
+datasets making it easier to conduct comparative linguistic analyses, manage 
+language data, and apply statistical methods directly within R.
+
 ## Installation
 
 You can install rcldf directly from [GitHub](https://github.com/SimonGreenhill/rcldf) using `devtools`:


### PR DESCRIPTION
The JOSS review requires "A statement of need" and there is a good description what this package does and why it is needed in the DESCRIPTION file that creates the package documentation. But it is not mentioned in the README.md file, which is probably the primary source of information for possible users of this library. 

I copied the description to the start of the README.md, which I think makes it easier to understand what the packages does even if someones does not know CLDF yet.

This PR is part of https://github.com/openjournals/joss-reviews/issues/10811